### PR TITLE
Added support for Onduis Analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,10 @@
     <link rel="stylesheet" href="https://unpkg.com/tailwindcss@2.2.19/dist/tailwind.min.css"/> <!--Replace with your tailwind.css once created-->
     <link href="https://afeld.github.io/emoji-css/emoji.css" rel="stylesheet"> <!--Totally optional :) -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.8.0/Chart.bundle.min.js" integrity="sha256-xKeoJ50pzbUGkpQxDYHD7o7hxe0LaOGeguUidbq6vis=" crossorigin="anonymous"></script>
+    <!--- Added support for Onduis Analytics Seamless Tracking -->
+    <script data-host="https://onduis.com" data-dnt="true" src="https://magic.onduis.com/js/script.js" id="ZwSg9rf6GA" async defer></script>
 
+    
 </head>
 
 <body class="bg-gray-800 font-sans leading-normal tracking-normal mt-12">


### PR DESCRIPTION
Added support for Onduis Analytics, users can create accounts on Onduis.com and after adding the website, the tracker will work automatically